### PR TITLE
Nested workflows, scatter, fixes for workflow output

### DIFF
--- a/cwl2wdl/base_classes.py
+++ b/cwl2wdl/base_classes.py
@@ -110,6 +110,7 @@ class SubWorkflow(object):
         self.task_definition = Workflow(step["definition"])
         self.inputs = [StepInput(i) for i in step['inputs']]
         self.outputs = [StepOutput(o) for o in step['outputs']]
+        self.scatter = step.get("scatter", [])
 
 class Step(object):
     def __init__(self, workflow_step):
@@ -119,6 +120,7 @@ class Step(object):
         self.import_statement = workflow_step.get('import_statement', "")
         self.inputs = [StepInput(i) for i in workflow_step['inputs']]
         self.outputs = [StepOutput(o) for o in workflow_step['outputs']]
+        self.scatter = workflow_step.get("scatter", [])
 
 
 class StepInput(object):

--- a/cwl2wdl/base_classes.py
+++ b/cwl2wdl/base_classes.py
@@ -98,14 +98,25 @@ class Workflow(object):
         self.inputs = [Input(i) for i in parsed_workflow['inputs']]
         self.outputs = [Output(o) for o in parsed_workflow['outputs']]
         self.steps = [Step(s) for s in parsed_workflow['steps']]
+        self.subworkflows = [SubWorkflow(w) for w in parsed_workflow.get("subworkflows", [])]
         self.requirements = [Requirement(r) for r in parsed_workflow['requirements']]
 
+class SubWorkflow(object):
+    """Step where we call a workflow from another workflow.
+    """
+    def __init__(self, step):
+        self.step_type = "workflow"
+        self.task_id = step["id"]
+        self.task_definition = Workflow(step["definition"])
+        self.inputs = [StepInput(i) for i in step['inputs']]
+        self.outputs = [StepOutput(o) for o in step['outputs']]
 
 class Step(object):
     def __init__(self, workflow_step):
+        self.step_type = "task"
         self.task_id = workflow_step['task_id']
         self.task_definition = Task(workflow_step['task_definition']) if workflow_step['task_definition'] is not None else None
-        self.import_statement = workflow_step['import_statement']
+        self.import_statement = workflow_step.get('import_statement', "")
         self.inputs = [StepInput(i) for i in workflow_step['inputs']]
         self.outputs = [StepOutput(o) for o in workflow_step['outputs']]
 

--- a/cwl2wdl/base_classes.py
+++ b/cwl2wdl/base_classes.py
@@ -57,6 +57,7 @@ class Input(object):
         self.default = input_dict['default']
         self.variable_type = input_dict['variable_type']
         self.is_required = input_dict['is_required']
+        self.separate = input_dict.get("separate", True)
 
 
 class Command(object):

--- a/cwl2wdl/generators.py
+++ b/cwl2wdl/generators.py
@@ -56,7 +56,7 @@ task %s {
             command_position.append(arg.position)
 
             if arg.prefix is not None:
-                arg_template = "%s %s"
+                arg_template = "%s %s" if arg.separate else "%s%s"
                 prefix = arg.prefix
             else:
                 arg_template = "%s%s"
@@ -91,7 +91,7 @@ task %s {
             else:
                 prefix = command_input.prefix
                 if command_input.is_required:
-                    command_input_template = "%s ${%s}"
+                    command_input_template = "%s ${%s}" if command_input.separate else "%s${%s}"
                 else:
                     command_input_template = "${%s + %s}"
 
@@ -171,11 +171,11 @@ task %s {
 class WdlWorkflowGenerator(object):
     def __init__(self, workflow):
         self.template = """
-%s
 workflow %s {
     %s
     %s
 }
+%s
 """
         self.name = workflow.name
         self.inputs = workflow.inputs
@@ -227,7 +227,7 @@ workflow %s {
         return "\n".join(steps)
 
     def generate_wdl(self):
-        wdl = self.template % ("\n".join(self.imported_tasks), self.name,
-                               self.__format_inputs(), self.__format_steps())
+        wdl = self.template % (self.name, self.__format_inputs(), self.__format_steps(),
+                               "\n".join(self.imported_tasks))
 
         return wdl

--- a/cwl2wdl/generators.py
+++ b/cwl2wdl/generators.py
@@ -233,12 +233,26 @@ workflow %s {
                         "%s%s=%s" % (pad, re.sub(step.task_id + "\.", "", inp.input_id),
                                      inp.value)
                     )
-                steps.append(step_template % (step.task_id,
-                                              ", \n".join(inputs)))
+                steps.append(self._format_scatter(step.scatter,
+                                                  step_template % (step.task_id, ", \n".join(inputs))))
             else:
                 step_template = "call %s"
-                steps.append(step_template % (step.task_id))
+                steps.append(self._format_scatter(step.scatter, step_template % (step.task_id)))
         return "\n".join(steps)
+
+    def _format_scatter(self, scatter, body):
+        """Add scatter information to a workflow step.
+        """
+        if scatter:
+            parts = ["  " + l for l in body.split("\n")]
+            scatter_parts = ["%s in %s" % (x, y) for x, y in scatter]
+            template = """
+    scatter (%s) {
+%s
+    }
+"""
+            body = template % ("\n             ".join(scatter_parts), "\n".join(parts))
+        return body
 
     def generate_wdl(self):
         wdl = self.template % (self.name, self.__format_inputs(), self.__format_steps(),

--- a/cwl2wdl/generators.py
+++ b/cwl2wdl/generators.py
@@ -181,6 +181,7 @@ workflow %s {
         self.inputs = workflow.inputs
         self.outputs = workflow.outputs
         self.steps = workflow.steps
+        self.subworkflows = workflow.subworkflows
         self.task_ids = []
         self.imported_tasks = []
 
@@ -199,13 +200,13 @@ workflow %s {
 
     def __format_steps(self):
         steps = []
-        for step in self.steps:
+        for step in self.steps + self.subworkflows:
             self.task_ids.append(step.task_id)
 
             if step.task_definition is not None:
-                self.imported_tasks.append(
-                    WdlTaskGenerator(step.task_definition).generate_wdl()
-                )
+                task_gen = (WdlTaskGenerator(step.task_definition) if step.step_type == "task"
+                            else WdlWorkflowGenerator(step.task_definition))
+                self.imported_tasks.append(task_gen.generate_wdl())
 
             if step.inputs != []:
                 step_template = """


### PR DESCRIPTION
Adam;
Thanks so much for this converter. I've been working on extending it with the goal of converting bcbio CWL workflows into WDL output and have an in-progress script that uses cwltool for parsing and cwl2wdl for WDL output generation:

https://github.com/chapmanb/bcbio-nextgen/blob/master/scripts/utils/cwltool2wdl.py

During this process I've added in some fixes and improvements to cwl2wdl and was hoping to contribute these:
- Support for nested sub-workflows
- Allow scattering of tasks and sub-workflows
- Bugfix to ensure tasks get correctly output
- Bugfix to include outputs in workflow definitions
- Support the CWL `separate` argument for commandline creation

In general, it would be great to collaborate with you on this and contribute the script as well once it's finalized and tested. My goal is to be able to convert a subset of CWL to WDL, avoiding more complex things like the expression languages. I think this will be a useful place to define a minimal subset of functionality that can support both and hopefully build additional collaboration between the two communities.

Thanks again for this work and for looking at these changes.
